### PR TITLE
Remove warning caused by outline property

### DIFF
--- a/src/Omnibox.js
+++ b/src/Omnibox.js
@@ -24,7 +24,6 @@ const styles = StyleSheet.create({
     borderWidth: 0,
     borderRadius: '4px',
     fontSize: '1rem',
-    outline: 'none',
     paddingLeft: 10,
     paddingRight: 44,
   },


### PR DESCRIPTION
## Problem

[![Screenshot from Gyazo](https://gyazo.com/9038380ae1e86017cebea5221e26af9e/raw)](https://gyazo.com/9038380ae1e86017cebea5221e26af9e)

- In my project using `react-native-web^0.11.7` , the warning was occurred by `outline` property.


## Factor

- In `react-native-web^0.1.1` that using in this package, `outline` property is valid.
- From `react-native-web@0.11.0` , `outline` property was replaced with `outline{Color,Style,Width}` .
	- See https://github.com/necolas/react-native-web/commit/f048d848a14fdd255cfabf1e32f8c55adc2622f0
- So, deprecated property, `outline` makes warning in project using `react-native-web@0.11.0` or newer.


## Solution

- Remove `outline` property from `Omnibox` style.
	- Use custom style options of `Omnibox` if you want to change outline style.
