### PR TITLE
Add <Overlay> Component API

### DIFF
--- a/docs/stories/index.js
+++ b/docs/stories/index.js
@@ -149,6 +149,20 @@ storiesOf('Marker', module)
     </View>
   ));
 
+storiesOf('Overlay', module).add('basic', () => (
+  <View style={styles.container}>
+    <MapView
+      ref={map => (this.map = map)}
+      region={{ latitude: 40.74, longitude: -74.18 }}
+      defaultZoom={13}>
+      <MapView.Overlay
+        image={{ uri: 'https://www.lib.utexas.edu/maps/historical/newark_nj_1922.jpg' }}
+        bounds={[[40.773941, -74.22655], [40.712216, -74.12544]]}
+      />
+    </MapView>
+  </View>
+));
+
 const styles = StyleSheet.create({
   container: {
     height: '100vh',

--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+class MapOverlay extends React.Component {
+  componentWillUnmount() {
+    console.log(this.overlay);
+    if (!this.overlay) return;
+    this.overlay.setMap(null);
+  }
+
+  componentWillUpdate() {
+    if (this.overlay || !this.props.map || !this.props.maps) return null;
+    const [[north, west], [south, east]] = this.props.bounds;
+    this.overlay = new this.props.maps.GroundOverlay(this.props.image.uri, {
+      north,
+      south,
+      east,
+      west,
+    });
+    this.overlay.setMap(this.props.map);
+  }
+
+  render() {
+    return null;
+  }
+}
+
+export default MapOverlay;

--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -1,12 +1,16 @@
 import React from 'react';
 
 class MapOverlay extends React.Component {
+  shouldComponentUpdate(nextProps) {
+    return !this.overlay && nextProps.map && nextProps.maps;
+  }
+
   componentWillUnmount() {
     if (!this.overlay) return;
     this.overlay.setMap(null);
   }
 
-  componentWillUpdate() {
+  componentDidUpdate() {
     if (this.overlay || !this.props.map || !this.props.maps) return null;
     const [[north, west], [south, east]] = this.props.bounds;
     this.overlay = new this.props.maps.GroundOverlay(this.props.image.uri, {

--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -2,7 +2,6 @@ import React from 'react';
 
 class MapOverlay extends React.Component {
   componentWillUnmount() {
-    console.log(this.overlay);
     if (!this.overlay) return;
     this.overlay.setMap(null);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,6 @@ class MapView extends Component {
 
     const childrenWithProps = React.Children.map(this.props.children, child => {
       if (child.type === Overlay) {
-        if (this.state.timeout) return null;
         return React.cloneElement(child, {
           map: this.state.map,
           maps: this.state.maps,

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { View, StyleSheet } from 'react-native';
 import GoogleMapReact from 'google-map-react';
 import Marker from './Marker';
+import Overlay from './Overlay';
 import Polyline from './Polyline';
 import Callout from './Callout';
 import Omnibox from './Omnibox';
@@ -49,6 +50,14 @@ class MapView extends Component {
     const zoom = (this.props.camera && this.props.camera.zoom) || this.props.defaultZoom || 15;
 
     const childrenWithProps = React.Children.map(this.props.children, child => {
+      if (child.type === Overlay) {
+        if (this.state.timeout) return null;
+        return React.cloneElement(child, {
+          map: this.state.map,
+          maps: this.state.maps,
+        });
+      }
+
       const { latitude, longitude } = child.props.coordinate;
       return React.cloneElement(child, {
         lat: latitude,
@@ -97,6 +106,7 @@ class MapView extends Component {
 }
 
 MapView.Marker = Marker;
+MapView.Overlay = Overlay;
 MapView.Polyline = Polyline;
 MapView.Callout = Callout;
 


### PR DESCRIPTION
## Proposal

- Add [`<Overlay>` component](https://github.com/react-native-community/react-native-maps/blob/master/docs/overlay.md) of [react-native-maps](https://github.com/react-native-community/react-native-maps).
- Make available to [Ground Overlays](https://developers.google.com/maps/documentation/javascript/groundoverlays) of Google Maps JavaScript API.

[![Screenshot from Gyazo](https://gyazo.com/0fc8d48f149461abb27060e493e57c78/raw)](https://gyazo.com/0fc8d48f149461abb27060e493e57c78)


## Feature

```jsx
<MapView>
    <MapView.Overlay
        image={source}
        bounds={LatLng[]}
    />
</MapView>
```

### Props

```ts
type ImageSource = {
    uri: string   // '<http location>'
}

type LatLng =  [number, number]

type OverlayProps = {
    image: ImageSource,
    bounds: [LatLng, LatLng]  // [[north, west], [south, east]]
}
```
