### PR TITLE
Set key for children of <MapView.Marker>

### DIFF
--- a/src/Marker.js
+++ b/src/Marker.js
@@ -59,7 +59,7 @@ class MapMarker extends Component {
     const calloutChildren = [];
     const markerChildren = [];
 
-    React.Children.forEach(this.props.children, child => {
+    React.Children.forEach(this.props.children, (child, index) => {
       if (child.type !== Callout) {
         markerChildren.push(child);
       } else {
@@ -67,6 +67,7 @@ class MapMarker extends Component {
           React.cloneElement(child, {
             hideCallout: this.hideCallout.bind(this),
             isOpen: this.state.isOpen,
+            key: child.props.key || index,
           })
         );
       }

--- a/src/index.js
+++ b/src/index.js
@@ -48,11 +48,12 @@ class MapView extends Component {
     };
     const zoom = (this.props.camera && this.props.camera.zoom) || this.props.defaultZoom || 15;
 
-    const childrenWithProps = React.Children.map(this.props.children, child => {
+    const childrenWithProps = React.Children.map(this.props.children, (child, index) => {
       const { latitude, longitude } = child.props.coordinate;
       return React.cloneElement(child, {
         lat: latitude,
         lng: longitude,
+        key: child.props.key || index,
       });
     });
 


### PR DESCRIPTION
## Problems

[![Screenshot from Gyazo](https://gyazo.com/7a3dbfb179c11434c519003a90281c97/raw)](https://gyazo.com/7a3dbfb179c11434c519003a90281c97)

- Resolve the warning of `key` props of `<MapView.Marker>` .
- This warning occur when
    - 2 or more than `<MapView.Callout>` in `<MapView.Marker>` .
    - 2 or more than marker children in `<MapView.Marker>` .

## Solutions

- Set `key` props for children of `<MapView.Marker>` .
